### PR TITLE
Fix error in FlashledBot example sketch

### DIFF
--- a/examples/101/FlashledBot/FlashledBot.ino
+++ b/examples/101/FlashledBot/FlashledBot.ino
@@ -23,7 +23,7 @@ const int ledPin = 13;
 #define BOTtoken "XXXXXXXXX:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"  // your Bot Token (Get from Botfather)
 
 WiFiSSLClient client;
-UniversalTelegramBot bot(BOTtoken, client);s
+UniversalTelegramBot bot(BOTtoken, client);
 
 int Bot_mtbs = 1000; //mean time between scan messages
 long Bot_lasttime;   //last time messages' scan has been done


### PR DESCRIPTION
A stray character caused compilation of the sketch to fail.

Fixes the build error noted in https://github.com/witnessmenow/Universal-Arduino-Telegram-Bot/pull/69.