### PR TITLE
Make maxMessageLength public.

### DIFF
--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -89,14 +89,14 @@ public:
   int longPoll = 0;
   bool _debug = false;
   int waitForResponse = 1500;
+  int maxMessageLength = 1300;
 
-private:
+  private:
   // JsonObject * parseUpdates(String response);
   String _token;
   Client *client;
   bool processResult(JsonObject &result, int messageIndex);
   void closeClient();
-  const int maxMessageLength = 1300;
 };
 
 #endif


### PR DESCRIPTION
After changes in Bot API 4.3 1300 characters might be too not enough.  
```
Added the field reply_markup to the Message object, containing the inline keyboard attached to the message.
```
So I think it's good to be able to edit this value.