### PR TITLE
Fix a bug where "null" was sent as keyboard markup

### DIFF
--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -699,7 +699,7 @@ String UniversalTelegramBot::sendPhoto(String chat_id, String photo,
     payload["reply_to_message_id"] = reply_to_message_id;
   }
 
-  if (keyboard) {
+  if (!keyboard.isEmpty()) {
     JsonObject &replyMarkup = payload.createNestedObject("reply_markup");
 
     DynamicJsonBuffer keyboardBuffer;


### PR DESCRIPTION
Only send keyboard markup array if it is not empty