### PR TITLE
BUGFIX: just a typo on making isEmpty() changes to length() > 0

### DIFF
--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -707,7 +707,7 @@ String UniversalTelegramBot::sendPhoto(const String& chat_id, const String& phot
   if (reply_to_message_id && reply_to_message_id != 0)
       payload["reply_to_message_id"] = reply_to_message_id;
 
-  if (!keyboard.length() > 0) {
+  if (keyboard.length() > 0) {
     JsonObject replyMarkup = payload.createNestedObject("reply_markup");
     replyMarkup["keyboard"] = serialized(keyboard);
   }


### PR DESCRIPTION
I believe this is a small bug ("cut&paste typo") introduced when making my changes on isEmpty() work on other platforms. The fix is small too