### PR TITLE
Message_id added in order to UPDATE messages and inlinekeyboard BUTTONS

### DIFF
--- a/examples/ESP32/LEDButtonUpdate/LEDButtonUpdate.ino
+++ b/examples/ESP32/LEDButtonUpdate/LEDButtonUpdate.ino
@@ -1,0 +1,176 @@
+/*******************************************************************
+    An example of how to use message_id to update an inline keyboard
+    message and buttons to toggle a LED
+    
+    written by Frits Jan van Kempen
+ *******************************************************************/
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <UniversalTelegramBot.h>
+
+// Initialize Wifi connection to the router
+const char *ssid = "mySSID";
+const char *password = "myPASSWORD";
+
+// Initialize Telegram BOT
+#define BOTtoken "xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxx" // your Bot Token (Get from Botfather)
+WiFiClientSecure client;
+UniversalTelegramBot bot(BOTtoken2, client);
+
+int Bot_mtbs = 1000; //mean time between scan messages
+long Bot_lasttime;   //last time messages' scan has been done
+int last_message_id = 0;
+
+// LED parameters
+const int ledPin = 2; // Internal LED on DevKit ESP32-WROOM (GPIO2)
+int ledState = LOW;
+
+void handleNewMessages(int numNewMessages)
+{
+
+    for (int i = 0; i < numNewMessages; i++)
+    {
+
+        // Get all the important data from the message
+        int message_id = bot.messages[i].message_id;
+        String chat_id = String(bot.messages[i].chat_id);
+        String text = bot.messages[i].text;
+        String from_name = bot.messages[i].from_name;
+        if (from_name == "")
+            from_name = "Guest";
+        String msg = ""; // init a message string to use
+
+        // Output the message_id to give you feeling on how this example works
+        Serial.print("Message id: ");
+        Serial.println(message_id);
+
+        // Inline buttons with callbacks when pressed will raise a callback_query message
+        if (bot.messages[i].type == "callback_query")
+        {
+            Serial.print("Call back button pressed by: ");
+            Serial.println(bot.messages[i].from_id);
+            Serial.print("Data on the button: ");
+            Serial.println(bot.messages[i].text);
+
+            if (text == "/toggleLED")
+            {
+
+                // Toggle the ledState and update the LED itself
+                ledState = !ledState;
+                digitalWrite(ledPin, ledState);
+
+                // Now we can UPDATE the message, lets prepare it for sending:
+                msg = "Hi " + from_name + "!\n";
+                msg += "Notice how the LED state has changed!\n\n";
+                msg += "Try it again, see the button has updated as well:\n\n";
+
+                // Prepare the buttons
+                String keyboardJson = "["; // start Json
+                keyboardJson += "[{ \"text\" : \"The LED is ";
+                if (ledState)
+                {
+                    keyboardJson += "ON";
+                }
+                else
+                {
+                    keyboardJson += "OFF";
+                }
+                keyboardJson += "\", \"callback_data\" : \"/toggleLED\" }]";
+                keyboardJson += ", [{ \"text\" : \"Send text\", \"callback_data\" : \"This text was sent by inline button\" }]"; // add another button
+                //keyboardJson += ", [{ \"text\" : \"Go to Google\", \"url\" : \"https://www.google.com\" }]"; // add another button, this one appears after first Update
+                keyboardJson += "]"; // end Json
+
+                // Now send this message including the current message_id as the 5th input to UPDATE that message
+                bot.sendMessageWithInlineKeyboard(chat_id, msg, "Markdown", keyboardJson, message_id);
+            }
+
+            else
+            {
+                // echo back callback_query which is not handled above
+                bot.sendMessage(chat_id, text, "Markdown");
+            }
+        }
+
+        // 'Normal' messages are handled here
+        else
+        {
+            if (text == "/start")
+            {
+                // lets create a friendly welcome message
+                msg = "Hi " + from_name + "!\n";
+                msg += "I am your Telegram Bot running on ESP32.\n\n";
+                msg += "Lets test this updating LED button below:\n\n";
+
+                // lets create a button depending on the current ledState
+                String keyboardJson = "["; // start of keyboard json
+                keyboardJson += "[{ \"text\" : \"The LED is ";
+                if (ledState)
+                {
+                    keyboardJson += "ON";
+                }
+                else
+                {
+                    keyboardJson += "OFF";
+                }
+                keyboardJson += "\", \"callback_data\" : \"/toggleLED\" }]";                                                     //callback is /toggleLED
+                keyboardJson += ", [{ \"text\" : \"Send text\", \"callback_data\" : \"This text was sent by inline button\" }]"; // add another button
+                keyboardJson += "]";                                                                                             // end of keyboard json
+
+                //first time, send this message as a normal inline keyboard message:
+                bot.sendMessageWithInlineKeyboard(chat_id, msg, "Markdown", keyboardJson);
+            }
+            if (text == "/options")
+            {
+                String keyboardJson = "[[{ \"text\" : \"Go to Google\", \"url\" : \"https://www.google.com\" }], [{ \"text\" : \"Send\", \"callback_data\" : \"This was sent by inline\" }]]";
+                bot.sendMessageWithInlineKeyboard(chat_id, "Choose from one of the following options", "", keyboardJson);
+            }
+        }
+    }
+}
+
+void setup()
+{
+    Serial.begin(115200);
+
+    // Attempt to connect to Wifi network:
+    Serial.print("Connecting Wifi: ");
+    Serial.println(ssid);
+
+    // Set WiFi to station mode and disconnect from an AP if it was Previously
+    // connected
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid, password);
+
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        Serial.print(".");
+        delay(500);
+    }
+
+    Serial.println("");
+    Serial.println("WiFi connected");
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+
+    pinMode(ledPin, OUTPUT);        // initialize ledPin as an output.
+    digitalWrite(ledPin, ledState); // initialize pin as low (LED Off)
+}
+
+void loop()
+{
+    // run this in loop to poll new messages
+    if (millis() > Bot_lasttime + Bot_mtbs)
+    {
+        int numNewMessages = bot.getUpdates(bot.last_message_received + 1);
+
+        while (numNewMessages)
+        {
+            Serial.println("got response");
+            handleNewMessages(numNewMessages);
+            numNewMessages = bot.getUpdates(bot.last_message_received + 1);
+        }
+
+        Bot_lasttime = millis();
+    }
+}

--- a/examples/ESP32/LEDButtonUpdate/README.md
+++ b/examples/ESP32/LEDButtonUpdate/README.md
@@ -1,0 +1,20 @@
+#ESP32 - LED button update
+
+This is an example of how one can update inline keyboard messages (buttons).
+The message_id of the specific message is sent when a message is received.
+This message_id can be used to UPDATE that message.
+One can update text inside a message, but also buttons can be updated.
+This way one can build menu's, like the menu the botfather uses.
+
+In this simple example we use a inlinekeyboard button to toggle (and update) the state of a LED.
+
+NOTE: You will need to enter your SSID, password and bot Token for the example to work.
+
+Example and update to Universal-Arduino-Telegram-Bot originally written by 
+[Frits Jan van Kempen] (https://github.com/fritsjan) with inspiration from [RomeHein] (https://github.com/RomeHein)
+
+Adapted by [Brian Lough](https://github.com/witnessmenow)
+
+## License
+
+You may copy, distribute and modify the software provided that modifications are described and licensed for free under [LGPL-3](http://www.gnu.org/licenses/lgpl-3.0.html). Derivatives works (including modifications or anything statically linked to the library) can only be redistributed under [LGPL-3](http://www.gnu.org/licenses/lgpl-3.0.html), but applications that use the library don't have to be.

--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -607,7 +607,7 @@ bool UniversalTelegramBot::sendMessageWithInlineKeyboard(const String& chat_id,
                                                          const String& text,
                                                          const String& parse_mode,
                                                          const String& keyboard,
-                                                         const int& message_id) {   // added message_id
+                                                         int message_id) {   // added message_id
 
   DynamicJsonDocument payload(maxMessageLength);
   payload["chat_id"] = chat_id;
@@ -628,7 +628,7 @@ bool UniversalTelegramBot::sendMessageWithInlineKeyboard(const String& chat_id,
  * SendPostMessage - function to send message to telegram              *
  * (Arguments to pass: chat_id, text to transmit and markup(optional)) *
  ***********************************************************************/
-bool UniversalTelegramBot::sendPostMessage(JsonObject payload, bool edit = false) { // added message_id
+bool UniversalTelegramBot::sendPostMessage(JsonObject payload, bool edit) { // added message_id
 
   bool sent = false;
   #ifdef TELEGRAM_DEBUG 

--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -562,16 +562,19 @@ bool UniversalTelegramBot::sendSimpleMessage(const String& chat_id, const String
 }
 
 bool UniversalTelegramBot::sendMessage(const String& chat_id, const String& text,
-                                       const String& parse_mode) {
+                                       const String& parse_mode, int message_id) { // added message_id
 
   DynamicJsonDocument payload(maxMessageLength);
   payload["chat_id"] = chat_id;
   payload["text"] = text;
 
+  if (message_id != 0)
+    payload["message_id"] = message_id; // added message_id
+
   if (parse_mode != "")
     payload["parse_mode"] = parse_mode;
 
-  return sendPostMessage(payload.as<JsonObject>());
+  return sendPostMessage(payload.as<JsonObject>(), message_id); // if message id == 0 then edit is false, else edit is true
 }
 
 bool UniversalTelegramBot::sendMessageWithReplyKeyboard(

--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -90,7 +90,7 @@ public:
                                     bool resize = false, bool oneTime = false,
                                     bool selective = false);
   bool sendMessageWithInlineKeyboard(const String& chat_id, const String& text,
-                                     const String& parse_mode, const String& keyboard, const int& message_id = 0); // added message id 
+                                     const String& parse_mode, const String& keyboard, int message_id = 0); // added message id 
 
   bool sendChatAction(const String& chat_id, const String& text);
 

--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -84,7 +84,7 @@ public:
   bool getMe();
 
   bool sendSimpleMessage(const String& chat_id, const String& text, const String& parse_mode);
-  bool sendMessage(const String& chat_id, const String& text, const String& parse_mode = "");
+  bool sendMessage(const String& chat_id, const String& text, const String& parse_mode = "", int message_id = 0); // added message id 
   bool sendMessageWithReplyKeyboard(const String& chat_id, const String& text,
                                     const String& parse_mode, const String& keyboard,
                                     bool resize = false, bool oneTime = false,


### PR DESCRIPTION
In order to make a menu or a toggle button we need to be able to UPDATE a message.
This pull request has the following improvements:

- message_id is now accessible for use
- a sendMessage() and sendMessageWithInlineKeyboard() have an extra option to send a message_id , if this is send, then the sendPostMessage() function will send a editMessageText command instead of a sendMessage command to Telegram

#155 was a guide for this pull-request, I just made it working to the latest standards ;-) Thanks RomeHein!
Also bugfixes from #186 are implemented (fix for not working photo send)
And some minor warnings are fixed
This also fixes #120 , #109 

Last but not least:

A working example (ESP32/LEDButtonUpdate) is added to show the basic working of this update option.