### PR TITLE
bugfix for [E][ssl_client.cpp:36] _handle_error(): [send_ssl_data():2…

### DIFF
--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -247,7 +247,7 @@ String UniversalTelegramBot::sendMultipartFormDataToTelegram(
     client->println(String(contentLength));
     client->print(F("Content-Type: multipart/form-data; boundary="));
     client->println(boundary);
-    client->println(F(""));
+    client->print("\r\n"); // bugfix for [E][ssl_client.cpp:36] _handle_error(): [send_ssl_data():294]: (0)
     client->print(start_request);
 
     #ifdef TELEGRAM_DEBUG  


### PR DESCRIPTION
…94]: (0), while sendPhotoByBinary()

In the Serial log, this error message is received while execution of sendPhotoByBinary().

This is a working bugfix on platformio using 
```
lib_deps = 
    # UniversalTelegramBot
    1262@^1.3

```