### PR TITLE
Implementation of SEND Location Telegram message

### DIFF
--- a/examples/ESP32/Location/Location.ino
+++ b/examples/ESP32/Location/Location.ino
@@ -41,6 +41,7 @@ void handleNewMessages(int numNewMessages)
       String message = "Long: " + String(bot.messages[i].longitude, 6) + "\n";
       message += "Lat: " + String(bot.messages[i].latitude, 6) + "\n";
       bot.sendMessage(chat_id, message, "Markdown");
+      bot.sendLocation(chat_id,bot.messages[i].latitude,bot.messages[i].longitude);
     }
     else if (text == "/start")
     {

--- a/examples/ESP8266/Location/Location.ino
+++ b/examples/ESP8266/Location/Location.ino
@@ -42,6 +42,7 @@ void handleNewMessages(int numNewMessages)
       String message = "Long: " + String(bot.messages[i].longitude, 6) + "\n";
       message += "Lat: " + String(bot.messages[i].latitude, 6) + "\n";
       bot.sendMessage(chat_id, message, "Markdown");
+      bot.sendLocation(chat_id,bot.messages[i].latitude,bot.messages[i].longitude);
     }
     else if (text == "/start")
     {

--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -769,6 +769,40 @@ bool UniversalTelegramBot::sendChatAction(const String& chat_id, const String& t
   return sent;
 }
 
+bool UniversalTelegramBot::sendLocation(const String& chat_id, const float latitude, const float longitude, uint16_t live_period) {
+
+  bool sent = false;
+  #ifdef TELEGRAM_DEBUG
+    Serial.println(F("SEND Location Message"));
+  #endif
+  unsigned long sttime = millis();
+
+    while (millis() - sttime < 8000ul) { // loop for a while to send the message
+      String command = BOT_CMD("sendLocation?chat_id=");
+      command += chat_id;
+      command += F("&latitude=");
+      command += String(latitude,6);
+      command += F("&longitude=");
+      command += String(longitude,6);
+      if ((live_period >= 60) && (live_period <= 86400)) {
+          command += F("&live_period=");
+          command += String(live_period);
+      }
+
+      String response = sendGetToTelegram(command);
+
+      #ifdef TELEGRAM_DEBUG
+        Serial.println(response);
+      #endif
+      sent = checkForOkResponse(response);
+
+      if (sent) break;
+    }
+
+  closeClient();
+  return sent;
+}
+
 void UniversalTelegramBot::closeClient() {
   if (client->connected()) {
     #ifdef TELEGRAM_DEBUG  

--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -444,7 +444,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
     messages[messageIndex].text = F("");
     messages[messageIndex].from_id = F("");
     messages[messageIndex].from_name = F("");
-     messages[messageIndex].username= F("");
+    messages[messageIndex].username= F("");
     messages[messageIndex].longitude = 0;
     messages[messageIndex].latitude = 0;
     messages[messageIndex].reply_to_message_id = 0;
@@ -456,7 +456,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
       messages[messageIndex].type = F("message");
       messages[messageIndex].from_id = message["from"]["id"].as<String>();
       messages[messageIndex].from_name = message["from"]["first_name"].as<String>();
-       messages[messageIndex].username= message["from"]["username"].as<String>();
+      messages[messageIndex].username= message["from"]["username"].as<String>();
       messages[messageIndex].date = message["date"].as<String>();
       messages[messageIndex].chat_id = message["chat"]["id"].as<String>();
       messages[messageIndex].chat_title = message["chat"]["title"].as<String>();

--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -444,6 +444,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
     messages[messageIndex].text = F("");
     messages[messageIndex].from_id = F("");
     messages[messageIndex].from_name = F("");
+     messages[messageIndex].username= F("");
     messages[messageIndex].longitude = 0;
     messages[messageIndex].latitude = 0;
     messages[messageIndex].reply_to_message_id = 0;
@@ -455,6 +456,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
       messages[messageIndex].type = F("message");
       messages[messageIndex].from_id = message["from"]["id"].as<String>();
       messages[messageIndex].from_name = message["from"]["first_name"].as<String>();
+       messages[messageIndex].username= message["from"]["username"].as<String>();
       messages[messageIndex].date = message["date"].as<String>();
       messages[messageIndex].chat_id = message["chat"]["id"].as<String>();
       messages[messageIndex].chat_title = message["chat"]["title"].as<String>();
@@ -495,6 +497,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
       messages[messageIndex].type = F("callback_query");
       messages[messageIndex].from_id = message["from"]["id"].as<String>();
       messages[messageIndex].from_name = message["from"]["first_name"].as<String>();
+      messages[messageIndex].username= message["from"]["username"].as<String>();
       messages[messageIndex].text = message["data"].as<String>();
       messages[messageIndex].date = message["date"].as<String>();
       messages[messageIndex].chat_id = message["message"]["chat"]["id"].as<String>();
@@ -508,6 +511,7 @@ bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
       messages[messageIndex].type = F("edited_message");
       messages[messageIndex].from_id = message["from"]["id"].as<String>();
       messages[messageIndex].from_name = message["from"]["first_name"].as<String>();
+      messages[messageIndex].username= message["from"]["username"].as<String>();
       messages[messageIndex].date = message["date"].as<String>();
       messages[messageIndex].chat_id = message["chat"]["id"].as<String>();
       messages[messageIndex].chat_title = message["chat"]["title"].as<String>();

--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -48,6 +48,7 @@ struct telegramMessage {
   String chat_title;
   String from_id;
   String from_name;
+  String username;
   String date;
   String type;
   String file_caption;

--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -94,7 +94,8 @@ public:
                                      const String& parse_mode, const String& keyboard, int message_id = 0);
 
   bool sendChatAction(const String& chat_id, const String& text);
-
+  bool sendLocation(const String& chat_id, const float latitude, const float longitude, const uint16_t live_period=0);
+  
   bool sendPostMessage(JsonObject payload, bool edit = false); 
   String sendPostPhoto(JsonObject payload);
   String sendPhotoByBinary(const String& chat_id, const String& contentType, int fileSize,


### PR DESCRIPTION
Added the Telegram sendLocation message to the Universal-Arduino-Telegram-Bot code. Prototype of the function is as follows:

bool sendLocation(const String& chat_id, const float latitude, const float longitude, const uint16_t live_period=0);

Location.ino examples under ESP32 and ESP8266 have been modified to also include the sendLocation message.

Tested this implementation of sendLocation command and seems to to work well. 