### PR TITLE
Update for lower resoruce boards

### DIFF
--- a/src/UniversalTelegramBot.cpp
+++ b/src/UniversalTelegramBot.cpp
@@ -436,7 +436,7 @@ int UniversalTelegramBot::getUpdates(long offset) {
 }
 
 bool UniversalTelegramBot::processResult(JsonObject result, int messageIndex) {
-  int update_id = result["update_id"];
+  long update_id = result["update_id"];
   // Check have we already dealt with this message (this shouldn't happen!)
   if (last_message_received != update_id) {
     last_message_received = update_id;


### PR DESCRIPTION
On the Arduino Uno (and other ATmega based boards) an int stores a 16-bit (2-byte) value. On the Arduino Due and SAMD based boards (like MKR1000 and Zero), an int stores a 32-bit (4-byte) value. 

This is a better type, as the first thing update_id is compared with, is another long "last_message_received". and the value from telegram is larger than 2 bytes

it will fix the multiple issues raised for low resource boards.