### PR TITLE
Nwesthoff fix bulk messages example

### DIFF
--- a/examples/ESP8266/BulkMessages/BulkMessages.ino
+++ b/examples/ESP8266/BulkMessages/BulkMessages.ino
@@ -32,11 +32,13 @@ JsonObject getSubscribedUsers()
   JsonObject users;
 
   // no file
-  if (!subscribedUsersFile)
-  {
+   if (!subscribedUsersFile) 
+   {
     Serial.println("Failed to open subscribed users file");
-    // Create empty file (w+ not working as expect)
+    // Create empty file (w+ not working as expected)
     File f = LittleFS.open(SUBSCRIBED_USERS_FILENAME, "w");
+    users = usersDoc.to<JsonObject>();
+    serializeJson(users, f);
     f.close();
     return users;
   }

--- a/examples/ESP8266/BulkMessages/BulkMessages.ino
+++ b/examples/ESP8266/BulkMessages/BulkMessages.ino
@@ -32,8 +32,8 @@ JsonObject getSubscribedUsers()
   JsonObject users;
 
   // no file
-   if (!subscribedUsersFile) 
-   {
+  if (!subscribedUsersFile)
+  {
     Serial.println("Failed to open subscribed users file");
     // Create empty file (w+ not working as expected)
     File f = LittleFS.open(SUBSCRIBED_USERS_FILENAME, "w");


### PR DESCRIPTION
The bulk messages example has an issue which causes it to not persist storage. The "no file" case returns a `null` value instead of an empty json object, making it impossible to write new entries to it. By initialising the value to `usersDoc.to<JsonObject>()` this is fixed.

Fixes https://github.com/witnessmenow/Universal-Arduino-Telegram-Bot/issues/232 and https://github.com/witnessmenow/Universal-Arduino-Telegram-Bot/issues/297