### PR TITLE
Added getUpdatesPoisonDrop() that DROPS messages that cause BUFFER OVERFLOW

### DIFF
--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -117,6 +117,9 @@ public:
   String buildCommand(const String& cmd);
 
   int getUpdates(long offset);
+  int getUpdatesPoisonDrop(long offset);
+  // Return true if the last getUpdatesPoisonDrop call dropped the poison drop
+  bool didGetUpdatesDropPoison();
   bool checkForOkResponse(const String& response);
   telegramMessage messages[HANDLE_MESSAGES];
   long last_message_received;
@@ -129,6 +132,8 @@ public:
   int maxMessageLength = 1500;
 
 private:
+  // State of the last getUpdatesPoisonDrop call
+  bool getUpdatesPoisonDropped = false;
   // JsonObject * parseUpdates(String response);
   String _token;
   Client *client;

--- a/src/UniversalTelegramBot.h
+++ b/src/UniversalTelegramBot.h
@@ -65,6 +65,14 @@ struct telegramMessage {
   String query_id;
 };
 
+struct DroppedUpdate {
+  bool active;
+  long update_id;
+  String from_id;
+  String from_name;
+  String chat_id;
+};
+
 class UniversalTelegramBot {
 public:
   UniversalTelegramBot(const String& token, Client &client);
@@ -120,6 +128,8 @@ public:
   int getUpdatesPoisonDrop(long offset);
   // Return true if the last getUpdatesPoisonDrop call dropped the poison drop
   bool didGetUpdatesDropPoison();
+  DroppedUpdate getLastDroppedUpdate();
+
   bool checkForOkResponse(const String& response);
   telegramMessage messages[HANDLE_MESSAGES];
   long last_message_received;
@@ -133,7 +143,7 @@ public:
 
 private:
   // State of the last getUpdatesPoisonDrop call
-  bool getUpdatesPoisonDropped = false;
+  DroppedUpdate lastDroppedUpdate = {false, 0, "", "", ""};
   // JsonObject * parseUpdates(String response);
   String _token;
   Client *client;


### PR DESCRIPTION
## **Summary**
The bot can enter a crash loop upon receiving a very large message (maliciously sent).

The standard `getUpdates` function fails to parse these large messages, preventing the `update_id` from advancing and causing the bot to endlessly retry and fail on the same message.

This exploit can be achieved by any telegram user that has the bot username and wants to crash your bot.

To solve this we can drop the very large message and return an error message to the client.

## **Changes Proposed**

1.  **New `getUpdatesPoisonDrop` Method**: 
    - Functionally similar to `getUpdates`, but drops poison messages to avoid the crash loop and extracts metadata from the raw partial response: user_id, chat_id, etc. This info could be used to send a response to the user ("message dropped").

2.  **State Tracking (`DroppedUpdate`)**:
    - Added a `DroppedUpdate` struct and `lastDroppedUpdate` state variable.
    - Unlike modifying the return value (which might break existing logic), this state allows developers to check `didGetUpdatesDropPoison()` after a call to see if a message was dropped.
    - Captures metadata like `from_id` and `chat_id` from the dropped message for logging or banning purposes.

## **Possible Improvements**

Merge the functions getUpdates and getUpdatesPoisonDrop into one (add an extra parameter for the `getUpdates( ... , dropPoison) `.

PS: This code was not completely tested (I use it in one of my personal projects and it works fine for me). Feel free to modify it as you wish.